### PR TITLE
Updates for compatibility with versions of Lean through `v4.0.0-m4-113-ge058fe65a9`

### DIFF
--- a/Bigop.lean
+++ b/Bigop.lean
@@ -116,7 +116,7 @@ syntax "def_bigop" str term:max term:max : command
 -- `F` is inserted only in the second expansion, the expansion of the new macro `$head`.
 macro_rules
   | `(def_bigop $head $op $unit) =>
-    `(macro $head:strLit "(" idx:index ")" F:term : term => `(\big_ [$op, $unit] ($$idx) $$F))
+    `(macro $head:str "(" idx:index ")" F:term : term => `(\big_ [$op, $unit] ($$idx) $$F))
 
 def_bigop "SUM" Nat.add 0
 #check SUM (i <- [0, 1, 2]) i+1

--- a/Bigop.lean
+++ b/Bigop.lean
@@ -32,11 +32,11 @@ instance [Enumerable α] [Enumerable β]: Enumerable (α × β) where
 
 def finElemsAux (n : Nat) : (i : Nat) → i < n → List (Fin n)
    | 0,   h => [⟨0, h⟩]
-   | i+1, h => ⟨i+1, h⟩ :: finElemsAux n i (Nat.ltOfSuccLt h)
+   | i+1, h => ⟨i+1, h⟩ :: finElemsAux n i (Nat.lt_of_succ_lt h)
 
 def finElems : (n : Nat) → List (Fin n)
    | 0     => []
-   | (n+1) => finElemsAux (n+1) n (Nat.ltSuccSelf n)
+   | (n+1) => finElemsAux (n+1) n (Nat.lt_succ_self n)
 
 instance : Enumerable (Fin n) where
   elems := (finElems n).reverse

--- a/Expander.lean
+++ b/Expander.lean
@@ -225,9 +225,8 @@ def expanderToFrontend (ref : Syntax) (e : ExpanderM Syntax) : FrontendM Syntax 
       else if k == `Lean.Parser.Term.paren then some expandParen
       -- `notation`, `macro`, and macros generated at runtime
       else
-        let table := (macroAttribute.ext.getState st.env).table
-        match table.find? k with
-        | some (t::_) => some (fun stx ctx =>
+        match macroAttribute.getValues st.env k with
+        | t::_ => some (fun stx ctx =>
           match t stx {
             mainModule := `Expander
             currMacroScope := ctx.currMacroScope

--- a/Expander.lean
+++ b/Expander.lean
@@ -234,8 +234,8 @@ def expanderToFrontend (ref : Syntax) (e : ExpanderM Syntax) : FrontendM Syntax 
             methods := Macro.mkMethods {
               expandMacro?     := fun stx => do
                 match (← expandMacroImpl? st.env stx) with
-                | some (_, stx') => some stx'
-                | none           => none
+                | some (_, Except.ok stx') => some stx'
+                | _                        => none
               hasDecl          := fun declName => return st.env.contains declName
               getCurrNamespace := return scope.currNamespace
               resolveNamespace? := fun n => return ResolveName.resolveNamespace? st.env scope.currNamespace scope.openDecls n

--- a/Expander.lean
+++ b/Expander.lean
@@ -232,13 +232,10 @@ def expanderToFrontend (ref : Syntax) (e : ExpanderM Syntax) : FrontendM Syntax 
             currMacroScope := ctx.currMacroScope
             ref := ref
             methods := Macro.mkMethods {
-              expandMacro?     := fun stx =>
-                try
-                  let newStx ← getMacros st.env stx
-                  pure (some newStx)
-                catch
-                  | Macro.Exception.unsupportedSyntax => pure none
-                  | ex                                => throw ex
+              expandMacro?     := fun stx => do
+                match (← expandMacroImpl? st.env stx) with
+                | some (_, stx') => some stx'
+                | none           => none
               hasDecl          := fun declName => return st.env.contains declName
               getCurrNamespace := return scope.currNamespace
               resolveNamespace? := fun n => return ResolveName.resolveNamespace? st.env scope.currNamespace scope.openDecls n

--- a/Expander.lean
+++ b/Expander.lean
@@ -124,8 +124,8 @@ partial def expand : Syntax → ExpanderM Syntax
   | `(fun $id:ident => $e) => do
     let e ← withLocal (getIdentVal id) (expand e)
     `(fun $id:ident => $e)
-  | `($num:numLit) => `($num:numLit)
-  | `($str:strLit) => `($str:strLit)
+  | `($num:num) => `($num:num)
+  | `($str:str) => `($str:str)
   | `($n:quotedName) => `($n:quotedName)
   | `($fn $args*) => do
     let fn ← expand fn
@@ -195,8 +195,8 @@ partial def pp : Syntax → Format
     | ps => ppIdent id.getId ++ bracket "{" (joinSep (ps.map (format ∘ Prod.fst)) ", ") "}"
   | `(fun ($id : $ty) => $e) => paren f!"fun {paren (pp id ++ " : " ++ pp ty)} => {pp e}"
   | `(fun $id => $e) => paren f!"fun {pp id} => {pp e}"
-  | `($num:numLit) => format (num.isNatLit?.getD 0)
-  | `($str:strLit) => repr (str.isStrLit?.getD "")
+  | `($num:num) => format (num.isNatLit?.getD 0)
+  | `($str:str) => repr (str.isStrLit?.getD "")
   | `($fn $args*) => paren <| pp fn ++ " " ++ joinSep (args.toList.map pp) line
   | `(def $id:ident := $e) => f!"def {ppIdent id.getId} := {pp e}"
   | `(syntax $[(name := $n)]? $[(priority := $prio)]? $[$args:stx]* : $kind) => "syntax ..."  -- irrelevant for this example

--- a/Expander.lean
+++ b/Expander.lean
@@ -72,7 +72,7 @@ def getPreresolved : Syntax → List NameRes
   | _                                            => []
 
 def mkOverloadedIds (cs : List NameRes) : Syntax :=
-  Syntax.node choiceKind (cs.toArray.map (mkIdent ∘ Prod.fst))
+  Syntax.node SourceInfo.none choiceKind (cs.toArray.map (mkIdent ∘ Prod.fst))
 
 def withLocal (l : Name) : ExpanderM Syntax → ExpanderM Syntax :=
   withReader (fun ctx => { ctx with lctx := ctx.lctx.insert l })
@@ -158,11 +158,11 @@ partial def quoteSyntax : Syntax → TransformerM Syntax
     let preresolved := resolve gctx val ++ preresolved
     `(Syntax.ident SourceInfo.none $(quote rawVal)
         (addMacroScope $(quote val) msc) $(quote preresolved))
-  | stx@(Syntax.node k args) =>
+  | stx@(Syntax.node _ k args) =>
     if isAntiquot stx then pure (getAntiquotTerm stx)
     else do
       let args ← args.mapM quoteSyntax
-      `(Syntax.node $(quote k) $(quote args))
+      `(Syntax.node SourceInfo.none $(quote k) $(quote args))
   | Syntax.atom info val => `(Syntax.atom SourceInfo.none $(quote val))
   | Syntax.missing => pure Syntax.missing
 

--- a/Expander.lean
+++ b/Expander.lean
@@ -183,7 +183,7 @@ def expandParen : Transformer
 -- custom Syntax pretty printer for our core forms that uses the paper's notation for hygienic identifiers
 def ppIdent (n : Name) : Format :=
   let v := extractMacroScopes n
-  fmt <| v.scopes.foldl Name.mkNum v.name
+  format <| v.scopes.foldl Name.mkNum v.name
 
 -- flip to make output more readable
 def hideMacroRulesRhs := false
@@ -192,10 +192,10 @@ open Std.Format
 partial def pp : Syntax → Format
   | `($id:ident) => match getPreresolved id with
     | [] => ppIdent id.getId
-    | ps => ppIdent id.getId ++ bracket "{" (joinSep (ps.map (fmt ∘ Prod.fst)) ", ") "}"
+    | ps => ppIdent id.getId ++ bracket "{" (joinSep (ps.map (format ∘ Prod.fst)) ", ") "}"
   | `(fun ($id : $ty) => $e) => paren f!"fun {paren (pp id ++ " : " ++ pp ty)} => {pp e}"
   | `(fun $id => $e) => paren f!"fun {pp id} => {pp e}"
-  | `($num:numLit) => fmt (num.isNatLit?.getD 0)
+  | `($num:numLit) => format (num.isNatLit?.getD 0)
   | `($str:strLit) => repr (str.isStrLit?.getD "")
   | `($fn $args*) => paren <| pp fn ++ " " ++ joinSep (args.toList.map pp) line
   | `(def $id:ident := $e) => f!"def {ppIdent id.getId} := {pp e}"

--- a/Expander.lean
+++ b/Expander.lean
@@ -97,9 +97,9 @@ partial def getPatternVars (stx : Syntax) : ExpanderM (Array Syntax) :=
   if stx.isQuot then
     getAntiquotationIds stx
   else match stx with
-    | `(_)            => #[]
-    | `($id:ident)    => #[id]
-    | `($id:ident@$e) => do (← getPatternVars e).push id
+    | `(_)            => pure #[]
+    | `($id:ident)    => pure #[id]
+    | `($id:ident@$e) => do return (← getPatternVars e).push id
     | _               => throw "unsupported pattern in syntax match"
 
 -- expand
@@ -234,8 +234,8 @@ def expanderToFrontend (ref : Syntax) (e : ExpanderM Syntax) : FrontendM Syntax 
             methods := Macro.mkMethods {
               expandMacro?     := fun stx => do
                 match (← expandMacroImpl? st.env stx) with
-                | some (_, Except.ok stx') => some stx'
-                | _                        => none
+                | some (_, Except.ok stx') => return some stx'
+                | _                        => return none
               hasDecl          := fun declName => return st.env.contains declName
               getCurrNamespace := return scope.currNamespace
               resolveNamespace? := fun n => return ResolveName.resolveNamespace? st.env scope.currNamespace scope.openDecls n

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:nightly-2021-04-29

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-08-08
+leanprover/lean4:nightly-2021-10-27

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-10-27
+leanprover/lean4:nightly-2021-11-12

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-08-02
+leanprover/lean4:nightly-2021-08-08

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-11-12
+leanprover/lean4:nightly-2022-02-05

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-06-22
+leanprover/lean4:nightly-2021-08-02

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-06-07
+leanprover/lean4:nightly-2021-06-22

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-02-05
+leanprover/lean4:nightly-2022-04-02

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-04-29
+leanprover/lean4:nightly-2021-06-07

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,4 +1,0 @@
-[package]
-name = "macro"
-version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-04-29"


### PR DESCRIPTION
I became interested in the exercise of ensuring compatibility with recent Lean versions while reading the Beyond Notations paper. I wanted to share my work in the hopes that it’s useful, either for you or just some fellow interested person.